### PR TITLE
issue#1_アジェンダの削除機能を実装

### DIFF
--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -33,7 +33,7 @@
             <span href="#" class="nav-link">
               <i class="fa fa-circle-o nav-icon"></i>
                 <%= agenda.title %>
-                <%= link_to '削除', agenda_path(agenda.id), method: :delete, data: { confirm: '本当に削除していいですか？', class: "btn-sm btn-default" } %>
+                <%= link_to 'Delete', agenda_path(agenda.id), method: :delete, data: { confirm: '本当に削除していいですか？', class: "btn-sm btn-default" } %>
                 <i class="right fa fa-angle-left"></i>
             </span>
             <ul class="nav nav-treeview" style="display: block;">


### PR DESCRIPTION
Closes #1 
- AgendasControllerのdestroyアクションを追加し、そこに機能追加する
- Agendaの名前の右の部分に削除ボタンを作成し、そのボタンを押すとそのAgendaが削除される
- Agendaに紐づいているarticleも一緒に削除される
- Agendaを削除できるのは、そのAgendaの作者もしくはそのAgendaに紐づいているTeamの作者（オーナー）のみ
- Agendaが削除されると、そのAgendaに紐づいているTeamに所属しているユーザー全員に通知メールが飛ぶ
- 情報処理が完了した後はDashBoardに飛ぶ
- その他、アプリケーションの挙動に不審な点やエラーがないこと