### PR TITLE
issue#2_チームリーダーが、他のチームメンバーにリーダー権限を渡せる機能を実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,8 @@ group :development, :test do
   gem 'guard-rspec'
   gem 'pry-byebug'
   gem 'pry-rails'
+  gem 'better_errors'
+  gem 'binding_of_caller'
   gem 'rspec-rails'
   gem 'rubocop', require: false
   gem 'rubocop-rails'

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -47,6 +47,20 @@ class TeamsController < ApplicationController
     @team = current_user.keep_team_id ? Team.find(current_user.keep_team_id) : current_user.teams.first
   end
 
+  def change_owner
+    #権限変更ボタンで指定したユーザーのIDをTeams._owner_idに変更すれば良い
+    team = Team.find(params[:id])
+    user = User.find(params[:assign_user])
+    team.owner_id = user.id
+    if team.update(team_params)
+      ChangeOwnerMailer.change_owner_mail(team, user).deliver
+      redirect_to team_path(team.id), notice: I18n.t('views.messages.update_team_owner')
+    else
+      flash.now[:error] = I18n.t('views.messages.failed_to_change_team_owner')
+      redirect_to team_path(team.id)
+    end
+  end
+
   private
 
   def set_team

--- a/app/mailers/change_owner_mailer.rb
+++ b/app/mailers/change_owner_mailer.rb
@@ -1,0 +1,7 @@
+class ChangeOwnerMailer < ApplicationMailer
+  def change_owner_mail(team, owner)
+    @team = team
+    @owner = owner
+    mail to: owner.email, subject: "#{team.name}チームのリーダに任命されました"
+  end
+end

--- a/app/views/change_owner_mailer/change_owner_mail.html.erb
+++ b/app/views/change_owner_mailer/change_owner_mail.html.erb
@@ -1,0 +1,3 @@
+<h1>チームリーダーに任命されました！</h1>
+<h4>team: <%= @team.name %></h4>
+<h4>mail: <%= @owner.email %></h4>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -42,6 +42,11 @@
                       <td><%= image_tag 'default.jpg', size: '40x40' %></td>
                       <td><%= assign.user.email %></td>
                       <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                      <td>
+                        <% if (current_user == @team.owner) && (current_user != assign.user) %>
+                          <%= link_to I18n.t('views.button.change_owner'), change_owner_team_path(@team.id, assign_user: assign.user), class: 'btn btn-sm btn-primary' %>
+                        <% end %>
+                      </td>
                     </tr>
                   <% end %>
                 </tbody>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -220,6 +220,8 @@ ja:
       create_team: 'チーム作成に成功しました！'
       failed_to_save_team: '保存に失敗しました、、'
       update_team: 'チーム更新に成功しました！'
+      update_team_owner: 'チームオーナーの更新に成功しました！'
+      failed_to_change_team_owner: 'チームオーナーの更新に失敗しました！'
       delete_team: 'チーム削除に成功しました！'
       update_profile: 'プロフィールを編集しました！'
       complete_registration: '登録完了'
@@ -259,6 +261,7 @@ ja:
       delete: '削除'
       create: '作成'
       invite: '招待'
+      change_owner: '権限変更'
     top:
       line1: 'このアプリケーションは、チームごと、議題ごとに別れて'
       line2: '特定のイシュー（議題）をメンバーで見やすく共有するためのアプリケーションです'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,13 +8,16 @@ Rails.application.routes.draw do
     passwords: 'users/passwords'
   }
   resource :user
-  
+
   resources :teams do
     resources :assigns, only: %w(create destroy)
     resources :agendas, shallow: true do
       resources :articles do
         resources :comments
       end
+    end
+    member do
+      get :change_owner
     end
   end
 

--- a/spec/mailers/change_owner_mailer_spec.rb
+++ b/spec/mailers/change_owner_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe ChangeOwnerMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/previews/change_owner_mailer_preview.rb
+++ b/spec/mailers/previews/change_owner_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/change_owner_mailer
+class ChangeOwnerMailerPreview < ActionMailer::Preview
+
+end


### PR DESCRIPTION
Closes #2 

- そのTeamのリーダー（オーナー）が、Teamのshowページを開くと、各チームメンバーの「削除」ボタンの右隣に「権限移動」のボタンが出現する
- そのボタンを押すと、そのTeamのオーナーが選択したUserに変更される
- アクションはTeamコントローラに任意のものを追加する
- Teamのオーナーが変更されたら、新しくオーナーになったユーザーに通知メールが飛ぶ
- 情報処理が完了した後はそのTeamのshowに飛ぶ（つまり同じ場所にredirectする）
- その他、アプリケーションの挙動に不審な点やエラーがないこと